### PR TITLE
fix: init installer log after elevation

### DIFF
--- a/cyberpanel_upgrade.sh
+++ b/cyberpanel_upgrade.sh
@@ -14,13 +14,6 @@
 Sudo_Test=$(set)
 #for SUDO check
 
-# Logging setup
-LOG_FILE="/var/log/installer.log"
-mkdir -p /var/log 2>/dev/null || true
-touch "$LOG_FILE" 2>/dev/null || true
-exec >>"$LOG_FILE" 2>&1
-echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] Upgrade started: $0 $*"
-
 # Re-exec with elevation if not running as root
 if [[ $(id -u) != 0 ]]; then
   SCRIPT_PATH="$(readlink -f "$0" 2>/dev/null || echo "$0")"
@@ -35,6 +28,13 @@ if [[ $(id -u) != 0 ]]; then
   echo "Please install sudo, doas, run0 (systemd), or pkexec (polkit) to continue."
   exit 1
 fi
+
+# Logging setup (requires root)
+LOG_FILE="/var/log/installer.log"
+mkdir -p /var/log 2>/dev/null || true
+touch "$LOG_FILE" 2>/dev/null || true
+exec >>"$LOG_FILE" 2>&1
+echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] Upgrade started: $0 $*"
 
 Set_Default_Variables() {
 

--- a/install.sh
+++ b/install.sh
@@ -3,13 +3,6 @@
 # CyberPanel v2.5.5-dev Installer
 # Simplified approach similar to stable branch
 
-# Logging setup
-LOG_FILE="/var/log/installer.log"
-mkdir -p /var/log 2>/dev/null || true
-touch "$LOG_FILE" 2>/dev/null || true
-exec >>"$LOG_FILE" 2>&1
-echo "[$(date +"%Y-%m-%d %H:%M:%S")] Installer started: $0 $*"
-
 # Re-exec with elevation if not running as root
 if [ "$(id -u)" -ne 0 ]; then
     SCRIPT_PATH="$(readlink -f "$0" 2>/dev/null || echo "$0")"
@@ -25,6 +18,13 @@ if [ "$(id -u)" -ne 0 ]; then
     echo "Please install sudo, doas, run0 (systemd), or pkexec (polkit) to continue."
     exit 1
 fi
+
+# Logging setup (requires root)
+LOG_FILE="/var/log/installer.log"
+mkdir -p /var/log 2>/dev/null || true
+touch "$LOG_FILE" 2>/dev/null || true
+exec >>"$LOG_FILE" 2>&1
+echo "[$(date +"%Y-%m-%d %H:%M:%S")] Installer started: $0 $*"
 
 # Determine branch from arguments or use default
 BRANCH_NAME="v2.5.5-dev"


### PR DESCRIPTION
Fix: move installer/upgrade logging setup after privilege elevation to avoid permission errors writing /var/log/installer.log when started as non-root.