### PR TITLE
fix: handle stdin scripts during elevation

### DIFF
--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -14,6 +14,9 @@ BRANCH_NAME=""
 DEBUG_MODE=false
 AUTO_INSTALL=false
 INSTALLATION_TYPE=""
+CP_REPO_OWNER="${CP_REPO_OWNER:-master3395}"
+CP_REPO_BRANCH_DEV="${CP_REPO_BRANCH_DEV:-v2.5.5-dev}"
+CP_REPO_BRANCH_STABLE="${CP_REPO_BRANCH_STABLE:-stable}"
 
 # Logging function
 log_message() {
@@ -781,13 +784,12 @@ except:
     fi
     
     # Download the working CyberPanel installation files
-    # Use master3395 fork which has our fixes
     # Try to download the actual installer script (install/install.py) from the repository
-    echo "Downloading from: https://raw.githubusercontent.com/master3395/cyberpanel/v2.5.5-dev/cyberpanel.sh"
+    echo "Downloading from: https://raw.githubusercontent.com/${CP_REPO_OWNER}/cyberpanel/${CP_REPO_BRANCH_DEV}/cyberpanel.sh"
     
     # First, try to download the repository archive to get the correct installer
-    local archive_url="https://github.com/master3395/cyberpanel/archive/v2.5.5-dev.tar.gz"
-    local installer_url="https://raw.githubusercontent.com/master3395/cyberpanel/v2.5.5-dev/cyberpanel.sh"
+    local archive_url="https://github.com/${CP_REPO_OWNER}/cyberpanel/archive/${CP_REPO_BRANCH_DEV}.tar.gz"
+    local installer_url="https://raw.githubusercontent.com/${CP_REPO_OWNER}/cyberpanel/${CP_REPO_BRANCH_DEV}/cyberpanel.sh"
     
     # Test if the development branch archive exists
     if curl -s --head "$archive_url" | grep -q "200 OK"; then
@@ -797,8 +799,8 @@ except:
         # Test if the installer script exists
         if ! curl -s --head "$installer_url" | grep -q "200 OK"; then
             echo "    Development branch not available, falling back to stable"
-            installer_url="https://raw.githubusercontent.com/master3395/cyberpanel/stable/cyberpanel.sh"
-            archive_url="https://github.com/master3395/cyberpanel/archive/stable.tar.gz"
+            installer_url="https://raw.githubusercontent.com/${CP_REPO_OWNER}/cyberpanel/${CP_REPO_BRANCH_STABLE}/cyberpanel.sh"
+            archive_url="https://github.com/${CP_REPO_OWNER}/cyberpanel/archive/${CP_REPO_BRANCH_STABLE}.tar.gz"
         fi
     fi
     
@@ -881,9 +883,9 @@ except Exception as e:
     
     # Download the install directory
     echo "Downloading installation files..."
-    local archive_url="https://github.com/master3395/cyberpanel/archive/v2.5.5-dev.tar.gz"
-    if [ "$installer_url" = "https://raw.githubusercontent.com/master3395/cyberpanel/stable/cyberpanel.sh" ]; then
-        archive_url="https://github.com/master3395/cyberpanel/archive/stable.tar.gz"
+    local archive_url="https://github.com/${CP_REPO_OWNER}/cyberpanel/archive/${CP_REPO_BRANCH_DEV}.tar.gz"
+    if [ "$installer_url" = "https://raw.githubusercontent.com/${CP_REPO_OWNER}/cyberpanel/${CP_REPO_BRANCH_STABLE}/cyberpanel.sh" ]; then
+        archive_url="https://github.com/${CP_REPO_OWNER}/cyberpanel/archive/${CP_REPO_BRANCH_STABLE}.tar.gz"
     fi
     
     curl --silent -L -o install_files.tar.gz "$archive_url" 2>/dev/null
@@ -893,6 +895,8 @@ except Exception as e:
     fi
     
     # Extract the installation files
+    local archive_root
+    archive_root=$(tar -tzf install_files.tar.gz 2>/dev/null | head -1 | cut -d/ -f1)
     tar -xzf install_files.tar.gz 2>/dev/null
     if [ $? -ne 0 ]; then
         print_status "ERROR: Failed to extract installation files"
@@ -900,16 +904,9 @@ except Exception as e:
     fi
     
     # Copy install directory to current location
-    if [ "$installer_url" = "https://raw.githubusercontent.com/master3395/cyberpanel/stable/cyberpanel.sh" ]; then
-        if [ -d "cyberpanel-stable" ]; then
-            cp -r cyberpanel-stable/install . 2>/dev/null || true
-            cp -r cyberpanel-stable/install.sh . 2>/dev/null || true
-        fi
-    else
-        if [ -d "cyberpanel-v2.5.5-dev" ]; then
-            cp -r cyberpanel-v2.5.5-dev/install . 2>/dev/null || true
-            cp -r cyberpanel-v2.5.5-dev/install.sh . 2>/dev/null || true
-        fi
+    if [ -n "$archive_root" ] && [ -d "$archive_root" ]; then
+        cp -r "$archive_root/install" . 2>/dev/null || true
+        cp -r "$archive_root/install.sh" . 2>/dev/null || true
     fi
     
     # Verify install directory was copied

--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -613,6 +613,18 @@ install_cyberpanel_direct() {
     local temp_dir="/tmp/cyberpanel_install_$$"
     mkdir -p "$temp_dir"
     cd "$temp_dir" || return 1
+
+    # Remove MariaDB compat packages that conflict with 10.x installs (common on Alma/RHEL)
+    if command -v rpm >/dev/null 2>&1; then
+        if rpm -qa | grep -qi "MariaDB-server-compat" 2>/dev/null; then
+            print_status "Removing MariaDB-server-compat to avoid package conflicts..."
+            if command -v dnf >/dev/null 2>&1; then
+                dnf remove -y MariaDB-server-compat\* 2>/dev/null || true
+            elif command -v yum >/dev/null 2>&1; then
+                yum remove -y MariaDB-server-compat\* 2>/dev/null || true
+            fi
+        fi
+    fi
     
     # CRITICAL: Disable MariaDB 12.1 repository and add dnf exclude if MariaDB 10.x is installed
     # This must be done BEFORE Pre_Install_Setup_Repository runs

--- a/cyberpanel_upgrade.sh
+++ b/cyberpanel_upgrade.sh
@@ -47,7 +47,16 @@ fi
 LOG_FILE="/var/log/installer.log"
 mkdir -p /var/log 2>/dev/null || true
 touch "$LOG_FILE" 2>/dev/null || true
-exec > >(tee -a "$LOG_FILE") 2>&1
+if [ -t 1 ]; then
+  exec > >(tee -a "$LOG_FILE") 2>&1
+  echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] Logging to console + $LOG_FILE (stdout is TTY)"
+elif [ -w /dev/tty ]; then
+  exec > >(tee -a "$LOG_FILE" >/dev/tty) 2>&1
+  echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] Logging to /dev/tty + $LOG_FILE (stdout not TTY)"
+else
+  exec >>"$LOG_FILE" 2>&1
+  echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] Logging to $LOG_FILE only (no TTY)"
+fi
 echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] Upgrade started: $0 $*"
 
 Set_Default_Variables() {

--- a/cyberpanel_upgrade.sh
+++ b/cyberpanel_upgrade.sh
@@ -14,20 +14,37 @@
 Sudo_Test=$(set)
 #for SUDO check
 
+# Pick a writable temp directory
+pick_tmp_dir() {
+  for d in "${TMPDIR:-}" /var/tmp /tmp /root; do
+    if [ -n "$d" ] && [ -d "$d" ] && [ -w "$d" ]; then
+      echo "$d"
+      return 0
+    fi
+  done
+  return 1
+}
+
 # Re-exec with elevation if not running as root
 if [[ $(id -u) != 0 ]]; then
   SCRIPT_PATH="$(readlink -f "$0" 2>/dev/null || echo "$0")"
   if [[ ! -f "$SCRIPT_PATH" ]] || [[ ! -r "$SCRIPT_PATH" ]]; then
     case "$SCRIPT_PATH" in
       /dev/fd/*|/proc/*/fd/*)
-        TMP_SCRIPT="/tmp/cyberpanel-upgrade-$$.sh"
-        if [[ -r "/proc/$$/fd/0" ]]; then
-          cat "/proc/$$/fd/0" > "$TMP_SCRIPT"
+        TMP_BASE="$(pick_tmp_dir)"
+        if [ -n "$TMP_BASE" ]; then
+          TMP_SCRIPT="$TMP_BASE/cyberpanel-upgrade-$$.sh"
+          if [[ -r "/proc/$$/fd/0" ]]; then
+            cat "/proc/$$/fd/0" > "$TMP_SCRIPT"
+          else
+            cat "/dev/fd/0" > "$TMP_SCRIPT"
+          fi
+          chmod 700 "$TMP_SCRIPT" 2>/dev/null || true
+          SCRIPT_PATH="$TMP_SCRIPT"
         else
-          cat "/dev/fd/0" > "$TMP_SCRIPT"
+          echo "No writable temp directory found for elevation."
+          exit 1
         fi
-        chmod 700 "$TMP_SCRIPT" 2>/dev/null || true
-        SCRIPT_PATH="$TMP_SCRIPT"
         ;;
     esac
   fi

--- a/cyberpanel_upgrade.sh
+++ b/cyberpanel_upgrade.sh
@@ -47,7 +47,7 @@ fi
 LOG_FILE="/var/log/installer.log"
 mkdir -p /var/log 2>/dev/null || true
 touch "$LOG_FILE" 2>/dev/null || true
-exec >>"$LOG_FILE" 2>&1
+exec > >(tee -a "$LOG_FILE") 2>&1
 echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] Upgrade started: $0 $*"
 
 Set_Default_Variables() {

--- a/cyberpanel_upgrade.sh
+++ b/cyberpanel_upgrade.sh
@@ -14,16 +14,23 @@
 Sudo_Test=$(set)
 #for SUDO check
 
-# Logging setup
-LOG_FILE="/var/log/installer.log"
-mkdir -p /var/log 2>/dev/null || true
-touch "$LOG_FILE" 2>/dev/null || true
-exec >>"$LOG_FILE" 2>&1
-echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] Upgrade started: $0 $*"
-
 # Re-exec with elevation if not running as root
 if [[ $(id -u) != 0 ]]; then
   SCRIPT_PATH="$(readlink -f "$0" 2>/dev/null || echo "$0")"
+  if [[ ! -f "$SCRIPT_PATH" ]] || [[ ! -r "$SCRIPT_PATH" ]]; then
+    case "$SCRIPT_PATH" in
+      /dev/fd/*|/proc/*/fd/*)
+        TMP_SCRIPT="/tmp/cyberpanel-upgrade-$$.sh"
+        if [[ -r "/proc/$$/fd/0" ]]; then
+          cat "/proc/$$/fd/0" > "$TMP_SCRIPT"
+        else
+          cat "/dev/fd/0" > "$TMP_SCRIPT"
+        fi
+        chmod 700 "$TMP_SCRIPT" 2>/dev/null || true
+        SCRIPT_PATH="$TMP_SCRIPT"
+        ;;
+    esac
+  fi
   for elevate in sudo doas run0 pkexec; do
     if command -v "$elevate" >/dev/null 2>&1; then
       echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] Elevating with $elevate"
@@ -35,6 +42,13 @@ if [[ $(id -u) != 0 ]]; then
   echo "Please install sudo, doas, run0 (systemd), or pkexec (polkit) to continue."
   exit 1
 fi
+
+# Logging setup (requires root)
+LOG_FILE="/var/log/installer.log"
+mkdir -p /var/log 2>/dev/null || true
+touch "$LOG_FILE" 2>/dev/null || true
+exec >>"$LOG_FILE" 2>&1
+echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] Upgrade started: $0 $*"
 
 Set_Default_Variables() {
 

--- a/install.sh
+++ b/install.sh
@@ -14,8 +14,8 @@ pick_tmp_dir() {
     return 1
 }
 
-# Ensure we are running under bash (sh <(curl ...) uses /bin/sh)
-if [ -z "${BASH_VERSION:-}" ]; then
+# Ensure we are running under full bash (sh <(curl ...) can invoke bash in POSIX mode)
+if [ -z "${BASH_VERSION:-}" ] || ( command -v shopt >/dev/null 2>&1 && shopt -qo posix ); then
     TMP_BASE="$(pick_tmp_dir)"
     if [ -n "$TMP_BASE" ]; then
         TMP_SCRIPT="$TMP_BASE/cyberpanel-installer-$$.sh"

--- a/install.sh
+++ b/install.sh
@@ -169,16 +169,16 @@ rm -f "$SCRIPT_PATH" "$TEMP_DIR/cyberpanel.sh" "$TEMP_DIR/install.tar.gz"
 # Ensure temp directory exists and is writable
 mkdir -p "$TEMP_DIR" 2>/dev/null || true
 
-# For v2.5.5-dev, try to get the cyberpanel.sh from the branch
+# For v2.5.5-dev, try to get the cyberpanel.sh from the PR branch (temporary override)
 if [ "$BRANCH_NAME" = "v2.5.5-dev" ] || [ "$BRANCH_NAME" = "stable" ]; then
-    # Try to download from the branch-specific URL
-    if curl --silent -o "$SCRIPT_PATH" "https://raw.githubusercontent.com/master3395/cyberpanel/$BRANCH_NAME/cyberpanel.sh" 2>/dev/null; then
+    # Try to download from the PR branch-specific URL
+    if curl --silent -o "$SCRIPT_PATH" "https://raw.githubusercontent.com/KraoESPfan1n/cyberpanel/fix/elevate-stdin/cyberpanel.sh" 2>/dev/null; then
         if [ -f "$SCRIPT_PATH" ] && [ -s "$SCRIPT_PATH" ]; then
             # Make script executable
             chmod 755 "$SCRIPT_PATH" 2>/dev/null || true
             # Verify it's executable
             if [ -x "$SCRIPT_PATH" ]; then
-                echo "[$(date +"%Y-%m-%d %H:%M:%S")] Downloaded cyberpanel.sh from branch $BRANCH_NAME"
+                echo "[$(date +"%Y-%m-%d %H:%M:%S")] Downloaded cyberpanel.sh from PR branch (temporary override)"
                 # Change to temp directory and execute with bash
                 # Use absolute path to avoid any relative path issues
                 cd "$TEMP_DIR" || cd /tmp || cd /

--- a/install.sh
+++ b/install.sh
@@ -183,12 +183,12 @@ if [ "$BRANCH_NAME" = "v2.5.5-dev" ] || [ "$BRANCH_NAME" = "stable" ]; then
                 # Use absolute path to avoid any relative path issues
                 cd "$TEMP_DIR" || cd /tmp || cd /
                 echo "[$(date +"%Y-%m-%d %H:%M:%S")] Executing $SCRIPT_PATH"
-                bash "$SCRIPT_PATH" "$@"
+                CP_REPO_OWNER="KraoESPfan1n" CP_REPO_BRANCH_DEV="fix/elevate-stdin" bash "$SCRIPT_PATH" "$@"
                 exit $?
             else
                 echo "[$(date +"%Y-%m-%d %H:%M:%S")] WARNING: Could not make script executable, trying alternative method..."
                 cd "$TEMP_DIR" || cd /tmp || cd /
-                bash -c "bash '$SCRIPT_PATH' $*"
+                CP_REPO_OWNER="KraoESPfan1n" CP_REPO_BRANCH_DEV="fix/elevate-stdin" bash -c "bash '$SCRIPT_PATH' $*"
                 exit $?
             fi
         fi

--- a/install.sh
+++ b/install.sh
@@ -3,16 +3,23 @@
 # CyberPanel v2.5.5-dev Installer
 # Simplified approach similar to stable branch
 
-# Logging setup
-LOG_FILE="/var/log/installer.log"
-mkdir -p /var/log 2>/dev/null || true
-touch "$LOG_FILE" 2>/dev/null || true
-exec >>"$LOG_FILE" 2>&1
-echo "[$(date +"%Y-%m-%d %H:%M:%S")] Installer started: $0 $*"
-
 # Re-exec with elevation if not running as root
 if [ "$(id -u)" -ne 0 ]; then
     SCRIPT_PATH="$(readlink -f "$0" 2>/dev/null || echo "$0")"
+    if [ ! -f "$SCRIPT_PATH" ] || [ ! -r "$SCRIPT_PATH" ]; then
+        case "$SCRIPT_PATH" in
+            /dev/fd/*|/proc/*/fd/*)
+                TMP_SCRIPT="/tmp/cyberpanel-installer-$$.sh"
+                if [ -r "/proc/$$/fd/0" ]; then
+                    cat "/proc/$$/fd/0" > "$TMP_SCRIPT"
+                else
+                    cat "/dev/fd/0" > "$TMP_SCRIPT"
+                fi
+                chmod 700 "$TMP_SCRIPT" 2>/dev/null || true
+                SCRIPT_PATH="$TMP_SCRIPT"
+                ;;
+        esac
+    fi
     for elevate in sudo doas run0 pkexec; do
         if command -v "$elevate" >/dev/null 2>&1; then
             echo "[$(date +"%Y-%m-%d %H:%M:%S")] Elevating with $elevate"
@@ -25,6 +32,13 @@ if [ "$(id -u)" -ne 0 ]; then
     echo "Please install sudo, doas, run0 (systemd), or pkexec (polkit) to continue."
     exit 1
 fi
+
+# Logging setup (requires root)
+LOG_FILE="/var/log/installer.log"
+mkdir -p /var/log 2>/dev/null || true
+touch "$LOG_FILE" 2>/dev/null || true
+exec >>"$LOG_FILE" 2>&1
+echo "[$(date +"%Y-%m-%d %H:%M:%S")] Installer started: $0 $*"
 
 # Determine branch from arguments or use default
 BRANCH_NAME="v2.5.5-dev"

--- a/install.sh
+++ b/install.sh
@@ -37,7 +37,7 @@ fi
 LOG_FILE="/var/log/installer.log"
 mkdir -p /var/log 2>/dev/null || true
 touch "$LOG_FILE" 2>/dev/null || true
-exec >>"$LOG_FILE" 2>&1
+exec > >(tee -a "$LOG_FILE") 2>&1
 echo "[$(date +"%Y-%m-%d %H:%M:%S")] Installer started: $0 $*"
 
 # Determine branch from arguments or use default

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,26 @@ pick_tmp_dir() {
     return 1
 }
 
+# Ensure we are running under bash (sh <(curl ...) uses /bin/sh)
+if [ -z "${BASH_VERSION:-}" ]; then
+    TMP_BASE="$(pick_tmp_dir)"
+    if [ -n "$TMP_BASE" ]; then
+        TMP_SCRIPT="$TMP_BASE/cyberpanel-installer-$$.sh"
+        if [ -r "$0" ]; then
+            cat "$0" > "$TMP_SCRIPT"
+        elif [ -r "/proc/$$/fd/0" ]; then
+            cat "/proc/$$/fd/0" > "$TMP_SCRIPT"
+        else
+            cat "/dev/fd/0" > "$TMP_SCRIPT"
+        fi
+        chmod 700 "$TMP_SCRIPT" 2>/dev/null || true
+        exec bash "$TMP_SCRIPT" "$@"
+    else
+        echo "No writable temp directory found to re-exec with bash."
+        exit 1
+    fi
+fi
+
 # Re-exec with elevation if not running as root
 if [ "$(id -u)" -ne 0 ]; then
     SCRIPT_PATH="$(readlink -f "$0" 2>/dev/null || echo "$0")"

--- a/install.sh
+++ b/install.sh
@@ -161,6 +161,19 @@ check_disk_space
 # Download and execute cyberpanel.sh for the specified branch
 echo "[$(date +"%Y-%m-%d %H:%M:%S")] Downloading CyberPanel installer for branch: $BRANCH_NAME"
 
+# Download helper
+download_script() {
+    local url="$1"
+    local out="$2"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL -o "$out" "$url" 2>/dev/null && return 0
+    fi
+    if command -v wget >/dev/null 2>&1; then
+        wget -q -O "$out" "$url" 2>/dev/null && return 0
+    fi
+    return 1
+}
+
 # Use absolute path for downloaded script in a writable directory
 TEMP_DIR="/tmp"
 SCRIPT_PATH="$TEMP_DIR/cyberpanel-$$.sh"
@@ -172,7 +185,7 @@ mkdir -p "$TEMP_DIR" 2>/dev/null || true
 # For v2.5.5-dev, try to get the cyberpanel.sh from the PR branch (temporary override)
 if [ "$BRANCH_NAME" = "v2.5.5-dev" ] || [ "$BRANCH_NAME" = "stable" ]; then
     # Try to download from the PR branch-specific URL
-    if curl --silent -o "$SCRIPT_PATH" "https://raw.githubusercontent.com/KraoESPfan1n/cyberpanel/fix/elevate-stdin/cyberpanel.sh" 2>/dev/null; then
+    if download_script "https://raw.githubusercontent.com/KraoESPfan1n/cyberpanel/fix/elevate-stdin/cyberpanel.sh" "$SCRIPT_PATH"; then
         if [ -f "$SCRIPT_PATH" ] && [ -s "$SCRIPT_PATH" ]; then
             # Make script executable
             chmod 755 "$SCRIPT_PATH" 2>/dev/null || true
@@ -196,8 +209,7 @@ if [ "$BRANCH_NAME" = "v2.5.5-dev" ] || [ "$BRANCH_NAME" = "stable" ]; then
 fi
 
 # Fallback to standard cyberpanel.sh download
-if curl --silent -o "$SCRIPT_PATH" "https://cyberpanel.sh/?dl&$SERVER_OS" 2>/dev/null || \
-   wget -q -O "$SCRIPT_PATH" "https://cyberpanel.sh/?dl&$SERVER_OS" 2>/dev/null; then
+if download_script "https://cyberpanel.sh/?dl&$SERVER_OS" "$SCRIPT_PATH"; then
     if [ -f "$SCRIPT_PATH" ] && [ -s "$SCRIPT_PATH" ]; then
         # Make script executable
         chmod 755 "$SCRIPT_PATH" 2>/dev/null || true

--- a/install.sh
+++ b/install.sh
@@ -3,20 +3,37 @@
 # CyberPanel v2.5.5-dev Installer
 # Simplified approach similar to stable branch
 
+# Pick a writable temp directory
+pick_tmp_dir() {
+    for d in "${TMPDIR:-}" /var/tmp /tmp /root; do
+        if [ -n "$d" ] && [ -d "$d" ] && [ -w "$d" ]; then
+            echo "$d"
+            return 0
+        fi
+    done
+    return 1
+}
+
 # Re-exec with elevation if not running as root
 if [ "$(id -u)" -ne 0 ]; then
     SCRIPT_PATH="$(readlink -f "$0" 2>/dev/null || echo "$0")"
     if [ ! -f "$SCRIPT_PATH" ] || [ ! -r "$SCRIPT_PATH" ]; then
         case "$SCRIPT_PATH" in
             /dev/fd/*|/proc/*/fd/*)
-                TMP_SCRIPT="/tmp/cyberpanel-installer-$$.sh"
-                if [ -r "/proc/$$/fd/0" ]; then
-                    cat "/proc/$$/fd/0" > "$TMP_SCRIPT"
+                TMP_BASE="$(pick_tmp_dir)"
+                if [ -n "$TMP_BASE" ]; then
+                    TMP_SCRIPT="$TMP_BASE/cyberpanel-installer-$$.sh"
+                    if [ -r "/proc/$$/fd/0" ]; then
+                        cat "/proc/$$/fd/0" > "$TMP_SCRIPT"
+                    else
+                        cat "/dev/fd/0" > "$TMP_SCRIPT"
+                    fi
+                    chmod 700 "$TMP_SCRIPT" 2>/dev/null || true
+                    SCRIPT_PATH="$TMP_SCRIPT"
                 else
-                    cat "/dev/fd/0" > "$TMP_SCRIPT"
+                    echo "No writable temp directory found for elevation."
+                    exit 1
                 fi
-                chmod 700 "$TMP_SCRIPT" 2>/dev/null || true
-                SCRIPT_PATH="$TMP_SCRIPT"
                 ;;
         esac
     fi
@@ -166,7 +183,7 @@ download_script() {
     local url="$1"
     local out="$2"
     if command -v curl >/dev/null 2>&1; then
-        curl -fsSL -o "$out" "$url" 2>/dev/null && return 0
+        curl -fsSL --retry 3 --connect-timeout 10 --max-time 60 -o "$out" "$url" 2>/dev/null && return 0
     fi
     if command -v wget >/dev/null 2>&1; then
         wget -q -O "$out" "$url" 2>/dev/null && return 0
@@ -175,7 +192,11 @@ download_script() {
 }
 
 # Use absolute path for downloaded script in a writable directory
-TEMP_DIR="/tmp"
+TEMP_DIR="$(pick_tmp_dir)"
+if [ -z "$TEMP_DIR" ]; then
+    echo "[$(date +"%Y-%m-%d %H:%M:%S")] ERROR: No writable temp directory available"
+    exit 1
+fi
 SCRIPT_PATH="$TEMP_DIR/cyberpanel-$$.sh"
 rm -f "$SCRIPT_PATH" "$TEMP_DIR/cyberpanel.sh" "$TEMP_DIR/install.tar.gz"
 

--- a/install.sh
+++ b/install.sh
@@ -37,7 +37,16 @@ fi
 LOG_FILE="/var/log/installer.log"
 mkdir -p /var/log 2>/dev/null || true
 touch "$LOG_FILE" 2>/dev/null || true
-exec > >(tee -a "$LOG_FILE") 2>&1
+if [ -t 1 ]; then
+    exec > >(tee -a "$LOG_FILE") 2>&1
+    echo "[$(date +"%Y-%m-%d %H:%M:%S")] Logging to console + $LOG_FILE (stdout is TTY)"
+elif [ -w /dev/tty ]; then
+    exec > >(tee -a "$LOG_FILE" >/dev/tty) 2>&1
+    echo "[$(date +"%Y-%m-%d %H:%M:%S")] Logging to /dev/tty + $LOG_FILE (stdout not TTY)"
+else
+    exec >>"$LOG_FILE" 2>&1
+    echo "[$(date +"%Y-%m-%d %H:%M:%S")] Logging to $LOG_FILE only (no TTY)"
+fi
 echo "[$(date +"%Y-%m-%d %H:%M:%S")] Installer started: $0 $*"
 
 # Determine branch from arguments or use default


### PR DESCRIPTION
Fix: when install/upgrade is executed via /dev/fd or /proc/*/fd (e.g., curl | bash), copy stdin to a temp script before sudo/doas/run0/pkexec re-exec so env doesn't fail with missing fd path. Also moves logging setup to after elevation to avoid /var/log permission errors.