### PR TITLE
Improve installer download flow

### DIFF
--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -15,6 +15,37 @@ DEBUG_MODE=false
 AUTO_INSTALL=false
 INSTALLATION_TYPE=""
 
+resolve_script_path() {
+    local candidate=""
+
+    if [ -n "$CYBERPANEL_SCRIPT_PATH" ] && [ -f "$CYBERPANEL_SCRIPT_PATH" ]; then
+        echo "$CYBERPANEL_SCRIPT_PATH"
+        return 0
+    fi
+
+    if [ -n "${BASH_SOURCE[0]}" ] && [ -f "${BASH_SOURCE[0]}" ]; then
+        candidate="${BASH_SOURCE[0]}"
+    elif [ -f "$0" ]; then
+        candidate="$0"
+    elif [ -f "./cyberpanel.sh" ]; then
+        candidate="./cyberpanel.sh"
+    elif [ -f "/workspaces/cyberpanel/cyberpanel.sh" ]; then
+        candidate="/workspaces/cyberpanel/cyberpanel.sh"
+    fi
+
+    if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+        # Prefer absolute path
+        if command -v realpath >/dev/null 2>&1; then
+            realpath "$candidate"
+        else
+            (cd "$(dirname "$candidate")" && pwd)/"$(basename "$candidate")"
+        fi
+        return 0
+    fi
+
+    return 1
+}
+
 # Require elevated permissions (auto-elevate)
 require_root() {
     if [ "$(id -u)" -eq 0 ]; then
@@ -27,10 +58,21 @@ require_root() {
         exit 1
     fi
 
+    local script_path=""
+    if script_path="$(resolve_script_path)"; then
+        export CYBERPANEL_SCRIPT_PATH="$script_path"
+    fi
+
     for elevate in sudo doas run0 pkexec; do
         if command -v "$elevate" >/dev/null 2>&1; then
             echo "Elevating with $elevate"
-            CYBERPANEL_ELEVATED=1 "$elevate" env "XDG_CONFIG_HOME=$XDG_CONFIG_HOME" "SUDO_USER=$(whoami)" "$0" "$@"
+            if [ -n "$CYBERPANEL_SCRIPT_PATH" ] && [ -f "$CYBERPANEL_SCRIPT_PATH" ]; then
+                CYBERPANEL_ELEVATED=1 "$elevate" env "XDG_CONFIG_HOME=$XDG_CONFIG_HOME" "SUDO_USER=$(whoami)" "$CYBERPANEL_SCRIPT_PATH" "$@"
+            else
+                echo "ERROR: Could not resolve script path for elevation."
+                echo "Please run: sudo /path/to/cyberpanel.sh [args...]"
+                exit 1
+            fi
             exit $?
         fi
     done

--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -915,13 +915,14 @@ except:
     fi
     
     # Download the working CyberPanel installation files
-    # Use master3395 fork which has our fixes
     # Try to download the actual installer script (install/install.py) from the repository
     echo "Downloading from: https://raw.githubusercontent.com/master3395/cyberpanel/v2.5.5-dev/cyberpanel.sh"
     
     # First, try to download the repository archive to get the correct installer
-    local archive_url="https://github.com/master3395/cyberpanel/archive/v2.5.5-dev.tar.gz"
-    local installer_url="https://raw.githubusercontent.com/master3395/cyberpanel/v2.5.5-dev/cyberpanel.sh"
+    local repo_owner="${CYBERPANEL_REPO_OWNER:-master3395}"
+    local repo_name="${CYBERPANEL_REPO_NAME:-cyberpanel}"
+    local archive_url="https://github.com/${repo_owner}/${repo_name}/archive/v2.5.5-dev.tar.gz"
+    local installer_url="https://raw.githubusercontent.com/${repo_owner}/${repo_name}/v2.5.5-dev/cyberpanel.sh"
     
     # Test if the development branch archive exists
     if curl -s --head "$archive_url" | grep -q "200 OK"; then
@@ -931,8 +932,8 @@ except:
         # Test if the installer script exists
         if ! curl -s --head "$installer_url" | grep -q "200 OK"; then
             echo "    Development branch not available, falling back to stable"
-            installer_url="https://raw.githubusercontent.com/master3395/cyberpanel/stable/cyberpanel.sh"
-            archive_url="https://github.com/master3395/cyberpanel/archive/stable.tar.gz"
+            installer_url="https://raw.githubusercontent.com/${repo_owner}/${repo_name}/stable/cyberpanel.sh"
+            archive_url="https://github.com/${repo_owner}/${repo_name}/archive/stable.tar.gz"
         fi
     fi
     
@@ -1015,9 +1016,9 @@ except Exception as e:
     
     # Download the install directory
     echo "Downloading installation files..."
-    local archive_url="https://github.com/master3395/cyberpanel/archive/v2.5.5-dev.tar.gz"
-    if [ "$installer_url" = "https://raw.githubusercontent.com/master3395/cyberpanel/stable/cyberpanel.sh" ]; then
-        archive_url="https://github.com/master3395/cyberpanel/archive/stable.tar.gz"
+    local archive_url="https://github.com/${repo_owner}/${repo_name}/archive/v2.5.5-dev.tar.gz"
+    if [ "$installer_url" = "https://raw.githubusercontent.com/${repo_owner}/${repo_name}/stable/cyberpanel.sh" ]; then
+        archive_url="https://github.com/${repo_owner}/${repo_name}/archive/stable.tar.gz"
     fi
     
     curl --silent -L -o install_files.tar.gz "$archive_url" 2>/dev/null
@@ -1034,7 +1035,7 @@ except Exception as e:
     fi
     
     # Copy install directory to current location
-    if [ "$installer_url" = "https://raw.githubusercontent.com/master3395/cyberpanel/stable/cyberpanel.sh" ]; then
+    if [ "$installer_url" = "https://raw.githubusercontent.com/${repo_owner}/${repo_name}/stable/cyberpanel.sh" ]; then
         if [ -d "cyberpanel-stable" ]; then
             cp -r cyberpanel-stable/install . 2>/dev/null || true
             cp -r cyberpanel-stable/install.sh . 2>/dev/null || true
@@ -1044,6 +1045,15 @@ except Exception as e:
             cp -r cyberpanel-v2.5.5-dev/install . 2>/dev/null || true
             cp -r cyberpanel-v2.5.5-dev/install.sh . 2>/dev/null || true
         fi
+    fi
+
+    # TEMP: Ensure Python installer files come from the same pushed branch
+    # Derive raw base URL from installer_url and refresh install/*.py
+    local raw_base=""
+    raw_base=$(echo "$installer_url" | sed -E 's#/cyberpanel\.sh$##')
+    if [ -n "$raw_base" ] && [ -d "install" ]; then
+        curl -sS "${raw_base}/install/install.py" -o install/install.py 2>/dev/null || true
+        curl -sS "${raw_base}/install/install_utils.py" -o install/install_utils.py 2>/dev/null || true
     fi
     
     # Verify install directory was copied

--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -38,7 +38,7 @@ resolve_script_path() {
         if command -v realpath >/dev/null 2>&1; then
             realpath "$candidate"
         else
-            (cd "$(dirname "$candidate")" && pwd)/"$(basename "$candidate")"
+            printf '%s/%s\n' "$(cd "$(dirname "$candidate")" && pwd)" "$(basename "$candidate")"
         fi
         return 0
     fi

--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -15,13 +15,28 @@ DEBUG_MODE=false
 AUTO_INSTALL=false
 INSTALLATION_TYPE=""
 
-# Require elevated permissions
+# Require elevated permissions (auto-elevate)
 require_root() {
-    if [ "$(id -u)" -ne 0 ]; then
-        echo "ERROR: This installer must be run with elevated privileges."
-        echo "Please re-run as root or with sudo."
+    if [ "$(id -u)" -eq 0 ]; then
+        return 0
+    fi
+
+    # Prevent infinite recursion
+    if [ -n "$CYBERPANEL_ELEVATED" ]; then
+        echo "ERROR: Failed to elevate privileges."
         exit 1
     fi
+
+    for elevate in sudo doas run0 pkexec; do
+        if command -v "$elevate" >/dev/null 2>&1; then
+            echo "Elevating with $elevate"
+            CYBERPANEL_ELEVATED=1 "$elevate" env "XDG_CONFIG_HOME=$XDG_CONFIG_HOME" "SUDO_USER=$(whoami)" "$0" "$@"
+            exit $?
+        fi
+    done
+
+    echo "Please install sudo, doas, run0 (systemd), or pkexec (polkit) to continue."
+    exit 1
 }
 
 # Base temp directory (avoid /tmp)
@@ -2916,7 +2931,7 @@ create_standard_aliases() {
 
 # Main installation function
 main() {
-    require_root
+    require_root "$@"
     # Initialize log directory and file
     mkdir -p "/var/log/CyberPanel"
     touch "/var/log/CyberPanel/install.log"

--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -15,6 +15,18 @@ DEBUG_MODE=false
 AUTO_INSTALL=false
 INSTALLATION_TYPE=""
 
+# Require elevated permissions
+require_root() {
+    if [ "$(id -u)" -ne 0 ]; then
+        echo "ERROR: This installer must be run with elevated privileges."
+        echo "Please re-run as root or with sudo."
+        exit 1
+    fi
+}
+
+# Base temp directory (avoid /tmp)
+TEMP_BASE="${HOME}/.cyberpanel_tmp"
+
 # Logging function
 log_message() {
     # Ensure log directory exists
@@ -145,6 +157,65 @@ detect_os() {
     return 0
 }
 
+# Ensure mysql CLI is available (or provide a compatible wrapper)
+ensure_mysql_command() {
+    if command -v mysql >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if command -v mariadb >/dev/null 2>&1; then
+        ln -sf "$(command -v mariadb)" /usr/local/bin/mysql 2>/dev/null || true
+        return 0
+    fi
+
+    if [ "$OS_FAMILY" = "rhel" ]; then
+        if command -v dnf >/dev/null 2>&1; then
+            dnf install -y mariadb >/dev/null 2>&1 || dnf install -y MariaDB-client >/dev/null 2>&1 || true
+        elif command -v yum >/dev/null 2>&1; then
+            yum install -y mariadb >/dev/null 2>&1 || yum install -y MariaDB-client >/dev/null 2>&1 || true
+        fi
+    elif [ "$OS_FAMILY" = "debian" ]; then
+        apt-get update -y >/dev/null 2>&1 || true
+        apt-get install -y mariadb-client >/dev/null 2>&1 || true
+    fi
+
+    if command -v mysql >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if command -v mariadb >/dev/null 2>&1; then
+        ln -sf "$(command -v mariadb)" /usr/local/bin/mysql 2>/dev/null || true
+    fi
+}
+
+# Remove MariaDB compat packages that conflict with MariaDB 10.x installs
+remove_mariadb_compat_packages() {
+    if command -v rpm >/dev/null 2>&1 && rpm -qa | grep -qiE "MariaDB-server-compat|mariadb-server-compat"; then
+        print_status "Removing MariaDB-server-compat packages to avoid conflicts..."
+        if command -v dnf >/dev/null 2>&1; then
+            dnf remove -y "MariaDB-server-compat*" "mariadb-server-compat*" >/dev/null 2>&1 || true
+        elif command -v yum >/dev/null 2>&1; then
+            yum remove -y "MariaDB-server-compat*" "mariadb-server-compat*" >/dev/null 2>&1 || true
+        fi
+    fi
+}
+
+# Ensure OpenLiteSpeed binaries exist (lswsctrl/openlitespeed)
+ensure_openlitespeed_binaries() {
+    if [ ! -x "/usr/local/lsws/bin/lswsctrl" ]; then
+        echo "  • OpenLiteSpeed binaries missing, attempting reinstall..."
+        if command -v dnf >/dev/null 2>&1; then
+            dnf install -y openlitespeed >/dev/null 2>&1 || true
+        elif command -v yum >/dev/null 2>&1; then
+            yum install -y openlitespeed >/dev/null 2>&1 || true
+        fi
+    fi
+
+    if [ -x "/usr/local/lsws/bin/lshttpd" ] && [ ! -x "/usr/local/lsws/bin/openlitespeed" ]; then
+        ln -sf "/usr/local/lsws/bin/lshttpd" "/usr/local/lsws/bin/openlitespeed" 2>/dev/null || true
+    fi
+}
+
 # Function to fix static file permissions (critical for LiteSpeed)
 fix_static_file_permissions() {
     echo "  🔧 Fixing static file permissions for web server access..."
@@ -198,6 +269,7 @@ fix_post_install_issues() {
     
     # Start and enable LiteSpeed if not running
     if ! systemctl is-active --quiet lsws; then
+        ensure_openlitespeed_binaries
         echo "    Starting LiteSpeed service..."
         systemctl start lsws
         systemctl enable lsws
@@ -206,6 +278,7 @@ fix_post_install_issues() {
     
     # Fix database user permissions
     echo "    Fixing database user permissions..."
+    ensure_mysql_command
     
     # Wait for MariaDB to be ready
     local retry_count=0
@@ -609,9 +682,25 @@ install_cyberpanel_direct() {
     systemctl enable mariadb 2>/dev/null || true
     systemctl enable lsws 2>/dev/null || true
     
-    # Create temporary directory for installation
-    local temp_dir="/tmp/cyberpanel_install_$$"
-    mkdir -p "$temp_dir"
+    # Remove MariaDB compat packages that cause conflicts
+    remove_mariadb_compat_packages
+
+    # Ensure mysql CLI is available (or provide a compatible wrapper)
+    ensure_mysql_command
+
+    # Pre-create OpenLiteSpeed directories to avoid custom binary install failures
+    mkdir -p /usr/local/lsws/bin /usr/local/lsws/modules 2>/dev/null || true
+    chmod 755 /usr/local/lsws /usr/local/lsws/bin 2>/dev/null || true
+
+    # Create temporary directory for installation (avoid /tmp)
+    local temp_dir
+    mkdir -p "$TEMP_BASE" 2>/dev/null || true
+    temp_dir="${TEMP_BASE}/install_$$"
+    rm -rf "$temp_dir" 2>/dev/null || true
+    mkdir -p "$temp_dir" 2>/dev/null || true
+    export TMPDIR="$temp_dir"
+    export TEMP="$temp_dir"
+    export TMP="$temp_dir"
     cd "$temp_dir" || return 1
     
     # CRITICAL: Disable MariaDB 12.1 repository and add dnf exclude if MariaDB 10.x is installed
@@ -753,7 +842,7 @@ except:
                     
                     # Also set up a background process to monitor and disable repos
                     (
-                        while [ ! -f /tmp/cyberpanel_install_complete ]; do
+                        while [ ! -f "$TEMP_BASE/cyberpanel_install_complete" ]; do
                             sleep 2
                             if [ -f /etc/yum.repos.d/mariadb-main.repo ] || [ -f /etc/yum.repos.d/mariadb.repo ]; then
                                 disable_mariadb_repos
@@ -761,7 +850,7 @@ except:
                         done
                     ) &
                     local monitor_pid=$!
-                    echo "$monitor_pid" > /tmp/cyberpanel_repo_monitor.pid
+                    echo "$monitor_pid" > "$TEMP_BASE/cyberpanel_repo_monitor.pid"
                     print_status "Started background process to monitor and disable MariaDB repositories"
                 fi
             fi
@@ -909,6 +998,67 @@ except Exception as e:
     fi
     
     print_status "Verified install directory exists"
+
+    # Patch install_utils.py to handle shell metacharacters and mysql commands safely
+    if [ -f "install/install_utils.py" ]; then
+        python3 - << 'PY' 2>/dev/null || true
+from pathlib import Path
+import re
+
+p = Path("install/install_utils.py")
+try:
+    text = p.read_text()
+except Exception:
+    raise SystemExit(0)
+
+if "CRITICAL: Use shell=True for commands with shell metacharacters" not in text:
+    snippet = """
+    # CRITICAL: Use shell=True for commands with shell metacharacters
+    # Avoids "No matching repo to modify: 2>/dev/null, true, ||" when shlex.split splits them
+    if not shell and any(x in command for x in (' || ', ' 2>/dev', ' 2>', ' | ', '; true', '|| true')):
+        shell = True
+
+    # CRITICAL: For mysql/mariadb commands, always use shell=True and full binary path
+    # This fixes "No such file or directory: 'mysql'" when run via shlex.split
+    if not shell and ('mysql' in command or 'mariadb' in command):
+        import re
+        mysql_bin = '/usr/bin/mariadb' if os.path.exists('/usr/bin/mariadb') else '/usr/bin/mysql'
+        if not os.path.exists(mysql_bin):
+            mysql_bin = '/usr/bin/mysql'
+        # Replace only leading "mysql" or "mariadb" (executable), not "mysql" in SQL like "use mysql;"
+        if re.match(r'^\\s*(sudo\\s+)?(mysql|mariadb)\\s', command):
+            command = re.sub(r'^(\\s*)(?:sudo\\s+)?(mysql|mariadb)(\\s)', r'\\g<1>' + mysql_bin + r'\\g<3>', command, count=1)
+        shell = True
+"""
+    pattern = r"(if 'apt-get' in command or 'apt ' in command:[\\s\\S]+?return False\\n)"
+    m = re.search(pattern, text)
+    if m:
+        insert_at = m.end()
+        text = text[:insert_at] + "\\n" + snippet + "\\n" + text[insert_at:]
+        p.write_text(text)
+PY
+    fi
+
+    # Patch install.py to avoid hardcoded /tmp paths
+    if [ -f "install/install.py" ]; then
+        python3 - << 'PY' 2>/dev/null || true
+from pathlib import Path
+import re
+
+p = Path("install/install.py")
+try:
+    text = p.read_text()
+except Exception:
+    raise SystemExit(0)
+
+if 'tmp_binary = "/tmp/openlitespeed-custom"' in text:
+    text = text.replace(
+        'tmp_binary = "/tmp/openlitespeed-custom"\\n            tmp_module = "/tmp/cyberpanel_ols.so"\\n',
+        'tmp_base = os.environ.get("TMPDIR", "/tmp")\\n            tmp_binary = f"{tmp_base}/openlitespeed-custom"\\n            tmp_module = f"{tmp_base}/cyberpanel_ols.so"\\n'
+    )
+    p.write_text(text)
+PY
+    fi
     
     echo "  ✓ CyberPanel installation files downloaded"
     echo "  🔄 Starting CyberPanel installation..."
@@ -1016,7 +1166,7 @@ except Exception as e:
         fi
         
         # If MariaDB 10.x is installed, disable repositories right before running installer
-        if [ -n "$MARIADB_VERSION" ] && [ -f /tmp/cyberpanel_repo_monitor.pid ]; then
+        if [ -n "$MARIADB_VERSION" ] && [ -f "$TEMP_BASE/cyberpanel_repo_monitor.pid" ]; then
             # Call the disable function one more time before installer runs
             if type disable_mariadb_repos >/dev/null 2>&1; then
                 disable_mariadb_repos
@@ -1216,7 +1366,7 @@ except Exception as e:
         fi
         
         # If MariaDB 10.x is installed, disable repositories right before running installer
-        if [ -n "$MARIADB_VERSION" ] && [ -f /tmp/cyberpanel_repo_monitor.pid ]; then
+        if [ -n "$MARIADB_VERSION" ] && [ -f "$TEMP_BASE/cyberpanel_repo_monitor.pid" ]; then
             # Call the disable function one more time before installer runs
             if type disable_mariadb_repos >/dev/null 2>&1; then
                 disable_mariadb_repos
@@ -1233,14 +1383,14 @@ except Exception as e:
     local install_exit_code=${PIPESTATUS[0]}
     
     # Stop the repository monitor
-    if [ -f /tmp/cyberpanel_repo_monitor.pid ]; then
-        local monitor_pid=$(cat /tmp/cyberpanel_repo_monitor.pid 2>/dev/null)
+    if [ -f "$TEMP_BASE/cyberpanel_repo_monitor.pid" ]; then
+        local monitor_pid=$(cat "$TEMP_BASE/cyberpanel_repo_monitor.pid" 2>/dev/null)
         if [ -n "$monitor_pid" ] && kill -0 "$monitor_pid" 2>/dev/null; then
             kill "$monitor_pid" 2>/dev/null
         fi
-        rm -f /tmp/cyberpanel_repo_monitor.pid
+        rm -f "$TEMP_BASE/cyberpanel_repo_monitor.pid"
     fi
-    touch /tmp/cyberpanel_install_complete 2>/dev/null || true
+    touch "$TEMP_BASE/cyberpanel_install_complete" 2>/dev/null || true
 
     local install_exit_code=${PIPESTATUS[0]}
 
@@ -1273,7 +1423,7 @@ except Exception as e:
     fi
     
     # Clean up temporary directory
-    cd /tmp
+    cd "$TEMP_BASE" 2>/dev/null || cd /
     rm -rf "$temp_dir" 2>/dev/null || true
     
     # Check if installation was successful
@@ -1349,10 +1499,12 @@ apply_fixes() {
     fi
 
     # Fix database issues
+    ensure_mysql_command
     systemctl start mariadb 2>/dev/null || true
     systemctl enable mariadb 2>/dev/null || true
 
     # Fix LiteSpeed service
+    ensure_openlitespeed_binaries
     cat > /etc/systemd/system/lsws.service << 'EOF'
 [Unit]
 Description=LiteSpeed Web Server
@@ -2196,7 +2348,7 @@ show_clean_menu() {
     read -r response
     case $response in
         [yY]|[yY][eE][sS])
-            rm -rf /tmp/cyberpanel_*
+            rm -rf "$TEMP_BASE"/cyberpanel_*
             rm -rf /var/log/cyberpanel_install.log
             echo "SUCCESS: Cleanup complete! Temporary files and logs have been removed."
             ;;
@@ -2764,6 +2916,7 @@ create_standard_aliases() {
 
 # Main installation function
 main() {
+    require_root
     # Initialize log directory and file
     mkdir -p "/var/log/CyberPanel"
     touch "/var/log/CyberPanel/install.log"

--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -760,8 +760,8 @@ install_cyberpanel_direct() {
     export TMP="$temp_dir"
     cd "$temp_dir" || return 1
     
-    # CRITICAL: Disable MariaDB 12.1 repository and add dnf exclude if MariaDB 10.x is installed
-    # This must be done BEFORE Pre_Install_Setup_Repository runs
+    # CRITICAL: Disable MariaDB 12.1 repository if MariaDB 10.x is installed
+    # Excluding MariaDB-server can break fresh reinstalls; only enable if explicitly requested.
     if command -v rpm >/dev/null 2>&1; then
         # Check if MariaDB 10.x is installed
         if rpm -qa | grep -qiE "^(mariadb-server|mysql-server|MariaDB-server)" 2>/dev/null; then
@@ -772,56 +772,17 @@ install_cyberpanel_direct() {
                 
                 # Check if it's MariaDB 10.x (major version < 12)
                 if [ "$major_ver" -lt 12 ]; then
-                    print_status "MariaDB $mariadb_version detected, adding dnf exclude to prevent upgrade attempts"
-                    
-                    # Add MariaDB-server to dnf excludes (multiple formats for compatibility)
-                    local dnf_conf="/etc/dnf/dnf.conf"
-                    local exclude_added=false
-                    
-                    if [ -f "$dnf_conf" ]; then
-                        # Check if [main] section exists
-                        if grep -q "^\[main\]" "$dnf_conf" 2>/dev/null; then
-                            # [main] section exists, add exclude there
-                            if ! grep -q "exclude=.*MariaDB-server" "$dnf_conf" 2>/dev/null; then
-                                if grep -q "^exclude=" "$dnf_conf" 2>/dev/null; then
-                                    # Append to existing exclude line in [main] section
-                                    sed -i '/^\[main\]/,/^\[/ { /^exclude=/ s/$/ MariaDB-server*/ }' "$dnf_conf"
-                                else
-                                    # Add new exclude line after [main]
-                                    sed -i '/^\[main\]/a exclude=MariaDB-server*' "$dnf_conf"
-                                fi
-                                exclude_added=true
-                            fi
-                        else
-                            # No [main] section, add it with exclude
-                            if ! grep -q "exclude=.*MariaDB-server" "$dnf_conf" 2>/dev/null; then
-                                echo "" >> "$dnf_conf"
-                                echo "[main]" >> "$dnf_conf"
-                                echo "exclude=MariaDB-server*" >> "$dnf_conf"
-                                exclude_added=true
-                            fi
+                    print_status "MariaDB $mariadb_version detected, disabling MariaDB 12.1 repos to prevent upgrade attempts"
+
+                    # Ensure MariaDB-server is not excluded unless explicitly requested
+                    if [ "${CYBERPANEL_EXCLUDE_MARIADB_SERVER:-0}" != "1" ]; then
+                        if [ -f /etc/dnf/dnf.conf ]; then
+                            sed -i 's/\s*MariaDB-server\*//g' /etc/dnf/dnf.conf 2>/dev/null || true
+                            sed -i 's/exclude=\s*$/# exclude=/' /etc/dnf/dnf.conf 2>/dev/null || true
                         fi
-                    else
-                        # Create dnf.conf with exclude
-                        echo "[main]" > "$dnf_conf"
-                        echo "exclude=MariaDB-server*" >> "$dnf_conf"
-                        exclude_added=true
-                    fi
-                    
-                    if [ "$exclude_added" = true ]; then
-                        print_status "Added MariaDB-server* to dnf excludes in $dnf_conf"
-                    fi
-                    
-                    # Also add to yum.conf for compatibility
-                    local yum_conf="/etc/yum.conf"
-                    if [ -f "$yum_conf" ]; then
-                        if ! grep -q "exclude=.*MariaDB-server" "$yum_conf" 2>/dev/null; then
-                            if grep -q "^exclude=" "$yum_conf" 2>/dev/null; then
-                                sed -i 's/^exclude=\(.*\)/exclude=\1 MariaDB-server*/' "$yum_conf"
-                            else
-                                echo "exclude=MariaDB-server*" >> "$yum_conf"
-                            fi
-                            print_status "Added MariaDB-server* to yum excludes"
+                        if [ -f /etc/yum.conf ]; then
+                            sed -i 's/\s*MariaDB-server\*//g' /etc/yum.conf 2>/dev/null || true
+                            sed -i 's/exclude=\s*$/# exclude=/' /etc/yum.conf 2>/dev/null || true
                         fi
                     fi
                     
@@ -943,8 +904,8 @@ except:
         return 1
     fi
     
-    # CRITICAL: Patch the installer script to skip MariaDB installation if 10.x is already installed
-    if [ -n "$MARIADB_VERSION" ] && [ "$major_ver" -lt 12 ] 2>/dev/null; then
+    # CRITICAL: Patch the installer script to skip MariaDB installation only if explicitly requested
+    if [ -n "$MARIADB_VERSION" ] && [ "$major_ver" -lt 12 ] 2>/dev/null && [ "${CYBERPANEL_EXCLUDE_MARIADB_SERVER:-0}" = "1" ]; then
         print_status "Patching installer script to skip MariaDB installation..."
         
         # Create a backup
@@ -1039,11 +1000,15 @@ except Exception as e:
         if [ -d "cyberpanel-stable" ]; then
             cp -r cyberpanel-stable/install . 2>/dev/null || true
             cp -r cyberpanel-stable/install.sh . 2>/dev/null || true
+            cp -r cyberpanel-stable/dns-one . 2>/dev/null || true
+            cp -r cyberpanel-stable/dns . 2>/dev/null || true
         fi
     else
         if [ -d "cyberpanel-v2.5.5-dev" ]; then
             cp -r cyberpanel-v2.5.5-dev/install . 2>/dev/null || true
             cp -r cyberpanel-v2.5.5-dev/install.sh . 2>/dev/null || true
+            cp -r cyberpanel-v2.5.5-dev/dns-one . 2>/dev/null || true
+            cp -r cyberpanel-v2.5.5-dev/dns . 2>/dev/null || true
         fi
     fi
 
@@ -1170,8 +1135,8 @@ PY
     if [ -f "$installer_py" ]; then
         print_status "Using install/install.py directly for installation (non-interactive mode)"
         
-        # CRITICAL: Patch install.py to exclude MariaDB-server from dnf/yum commands
-        if [ -n "$MARIADB_VERSION" ] && [ "$major_ver" -lt 12 ] 2>/dev/null; then
+        # CRITICAL: Patch install.py to exclude MariaDB-server only if explicitly requested
+        if [ -n "$MARIADB_VERSION" ] && [ "$major_ver" -lt 12 ] 2>/dev/null && [ "${CYBERPANEL_EXCLUDE_MARIADB_SERVER:-0}" = "1" ]; then
             print_status "Patching install.py to exclude MariaDB-server from installation commands..."
             
             # Create backup

--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -919,8 +919,8 @@ except:
     echo "Downloading from: https://raw.githubusercontent.com/master3395/cyberpanel/v2.5.5-dev/cyberpanel.sh"
     
     # First, try to download the repository archive to get the correct installer
-    local repo_owner="${CYBERPANEL_REPO_OWNER:-master3395}"
-    local repo_name="${CYBERPANEL_REPO_NAME:-cyberpanel}"
+    local repo_owner="KraoESPfan1n"
+    local repo_name="cyberpanel"
     local archive_url="https://github.com/${repo_owner}/${repo_name}/archive/v2.5.5-dev.tar.gz"
     local installer_url="https://raw.githubusercontent.com/${repo_owner}/${repo_name}/v2.5.5-dev/cyberpanel.sh"
     

--- a/install.sh
+++ b/install.sh
@@ -102,63 +102,57 @@ check_disk_space
 # Download and execute cyberpanel.sh for the specified branch
 echo "Downloading CyberPanel installer for branch: $BRANCH_NAME"
 
-# Use absolute path for downloaded script in a writable directory
-TEMP_DIR="/tmp"
-SCRIPT_PATH="$TEMP_DIR/cyberpanel-$$.sh"
-rm -f "$SCRIPT_PATH" "$TEMP_DIR/cyberpanel.sh" "$TEMP_DIR/install.tar.gz"
+# Use HOME because some distros have /tmp mounted noexec
+SCRIPT_PATH=$(mktemp --tmpdir="$HOME" cyberpanel.XXXXXX)
+trap 'rm -f "$SCRIPT_PATH"' EXIT
 
-# Ensure temp directory exists and is writable
-mkdir -p "$TEMP_DIR" 2>/dev/null || true
+echo "Downloading installer..."
 
-# For v2.5.5-dev, try to get the cyberpanel.sh from the branch
+download_ok=0
+
+# For v2.5.5-dev and stable, try the branch-specific URL first
 if [ "$BRANCH_NAME" = "v2.5.5-dev" ] || [ "$BRANCH_NAME" = "stable" ]; then
-    # Try to download from the branch-specific URL
-    if curl --silent -o "$SCRIPT_PATH" "https://raw.githubusercontent.com/master3395/cyberpanel/$BRANCH_NAME/cyberpanel.sh" 2>/dev/null; then
-        if [ -f "$SCRIPT_PATH" ] && [ -s "$SCRIPT_PATH" ]; then
-            # Make script executable
-            chmod 755 "$SCRIPT_PATH" 2>/dev/null || true
-            # Verify it's executable
-            if [ -x "$SCRIPT_PATH" ]; then
-                echo "✅ Downloaded cyberpanel.sh from branch $BRANCH_NAME"
-                # Change to temp directory and execute with bash
-                # Use absolute path to avoid any relative path issues
-                cd "$TEMP_DIR" || cd /tmp || cd /
-                bash "$SCRIPT_PATH" "$@"
-                exit $?
-            else
-                echo "⚠️  Warning: Could not make script executable, trying alternative method..."
-                cd "$TEMP_DIR" || cd /tmp || cd /
-                bash -c "bash '$SCRIPT_PATH' $*"
-                exit $?
-            fi
-        fi
+    if curl -sS "https://raw.githubusercontent.com/master3395/cyberpanel/$BRANCH_NAME/cyberpanel.sh" \
+        --output "$SCRIPT_PATH" \
+        --location \
+        --fail; then
+        download_ok=1
+        echo "✅ Downloaded cyberpanel.sh from branch $BRANCH_NAME"
     fi
 fi
 
 # Fallback to standard cyberpanel.sh download
-if curl --silent -o "$SCRIPT_PATH" "https://cyberpanel.sh/?dl&$SERVER_OS" 2>/dev/null || \
-   wget -q -O "$SCRIPT_PATH" "https://cyberpanel.sh/?dl&$SERVER_OS" 2>/dev/null; then
-    if [ -f "$SCRIPT_PATH" ] && [ -s "$SCRIPT_PATH" ]; then
-        # Make script executable
-        chmod 755 "$SCRIPT_PATH" 2>/dev/null || true
-        # Verify it's executable
-        if [ -x "$SCRIPT_PATH" ]; then
-            echo "✅ Downloaded cyberpanel.sh from standard source"
-            # Change to temp directory and execute with bash
-            # Use absolute path to avoid any relative path issues
-            cd "$TEMP_DIR" || cd /tmp || cd /
-            bash "$SCRIPT_PATH" "$@"
-            exit $?
-        else
-            echo "⚠️  Warning: Could not make script executable, trying alternative method..."
-            cd "$TEMP_DIR" || cd /tmp || cd /
-            bash -c "bash '$SCRIPT_PATH' $*"
-            exit $?
-        fi
+if [ "$download_ok" -eq 0 ]; then
+    if curl -sS "https://cyberpanel.sh/?dl&$SERVER_OS" \
+        --output "$SCRIPT_PATH" \
+        --location \
+        --fail; then
+        download_ok=1
+        echo "✅ Downloaded cyberpanel.sh from standard source"
     fi
 fi
 
-# If we get here, download failed
-echo "❌ Failed to download cyberpanel.sh"
-echo "Please check your internet connection and try again"
+if [ "$download_ok" -eq 0 ]; then
+    echo "❌ Failed to download cyberpanel.sh"
+    echo "Please check your internet connection and try again"
+    exit 1
+fi
+
+chmod +x "$SCRIPT_PATH" 2>/dev/null || true
+
+# If already root, run directly
+if [ "$(id -u)" -eq 0 ]; then
+    "$SCRIPT_PATH" "$@"
+    exit $?
+fi
+
+for elevate in sudo doas run0 pkexec; do
+    if command -v "$elevate" >/dev/null 2>&1; then
+        echo "Elevating with $elevate"
+        "$elevate" env "XDG_CONFIG_HOME=$XDG_CONFIG_HOME" "SUDO_USER=$(whoami)" "$SCRIPT_PATH" "$@"
+        exit $?
+    fi
+done
+
+echo "Please install sudo, doas, run0 (systemd), or pkexec (polkit) to continue."
 exit 1

--- a/install/install.py
+++ b/install/install.py
@@ -18,6 +18,10 @@ import secrets
 import install_utils
 
 TMP_BASE = os.environ.get("TMPDIR", "/tmp")
+try:
+    os.makedirs(TMP_BASE, exist_ok=True)
+except Exception:
+    pass
 
 VERSION = '2.4'
 BUILD = 4
@@ -1560,40 +1564,42 @@ module cyberpanel_ols {
                                     self.stdOut(f"Warning: Could not disable repository {repo_file}: {e}", 1)
                                     logging.InstallLog.writeToFile(f"Warning: Could not disable repository {repo_file}: {e}")
                         
-                        # Always exclude MariaDB-server from dnf/yum operations to prevent upgrades
-                        try:
-                            # Add exclude to dnf.conf
-                            dnf_conf = '/etc/dnf/dnf.conf'
-                            exclude_line = 'exclude=MariaDB-server'
-                            
-                            if os.path.exists(dnf_conf):
-                                with open(dnf_conf, 'r') as f:
-                                    dnf_content = f.read()
+                        # Optionally exclude MariaDB-server from dnf/yum operations to prevent upgrades
+                        # Disabled by default to avoid breaking fresh reinstalls
+                        if os.environ.get("CYBERPANEL_EXCLUDE_MARIADB_SERVER", "0") == "1":
+                            try:
+                                # Add exclude to dnf.conf
+                                dnf_conf = '/etc/dnf/dnf.conf'
+                                exclude_line = 'exclude=MariaDB-server'
                                 
-                                # Check if exclude line already exists
-                                if exclude_line not in dnf_content:
-                                    # Check if there's already an exclude line
-                                    if 'exclude=' in dnf_content:
-                                        # Append to existing exclude line
-                                        dnf_content = re.sub(r'(exclude=.*)', r'\1 MariaDB-server', dnf_content)
-                                    else:
-                                        # Add new exclude line
-                                        dnf_content = dnf_content.rstrip() + '\n' + exclude_line + '\n'
+                                if os.path.exists(dnf_conf):
+                                    with open(dnf_conf, 'r') as f:
+                                        dnf_content = f.read()
                                     
+                                    # Check if exclude line already exists
+                                    if exclude_line not in dnf_content:
+                                        # Check if there's already an exclude line
+                                        if 'exclude=' in dnf_content:
+                                            # Append to existing exclude line
+                                            dnf_content = re.sub(r'(exclude=.*)', r'\1 MariaDB-server', dnf_content)
+                                        else:
+                                            # Add new exclude line
+                                            dnf_content = dnf_content.rstrip() + '\n' + exclude_line + '\n'
+                                        
+                                        with open(dnf_conf, 'w') as f:
+                                            f.write(dnf_content)
+                                        self.stdOut("Added MariaDB-server to dnf excludes to prevent upgrade", 1)
+                                        logging.InstallLog.writeToFile("Added MariaDB-server to dnf excludes")
+                                else:
+                                    # Create dnf.conf with exclude
                                     with open(dnf_conf, 'w') as f:
-                                        f.write(dnf_content)
-                                    self.stdOut("Added MariaDB-server to dnf excludes to prevent upgrade", 1)
-                                    logging.InstallLog.writeToFile("Added MariaDB-server to dnf excludes")
-                            else:
-                                # Create dnf.conf with exclude
-                                with open(dnf_conf, 'w') as f:
-                                    f.write('[main]\n')
-                                    f.write(exclude_line + '\n')
-                                self.stdOut("Created dnf.conf with MariaDB-server exclude", 1)
-                                logging.InstallLog.writeToFile("Created dnf.conf with MariaDB-server exclude")
-                        except Exception as e:
-                            self.stdOut(f"Warning: Could not add exclude to dnf.conf: {e}", 1)
-                            logging.InstallLog.writeToFile(f"Warning: Could not add exclude to dnf.conf: {e}")
+                                        f.write('[main]\n')
+                                        f.write(exclude_line + '\n')
+                                    self.stdOut("Created dnf.conf with MariaDB-server exclude", 1)
+                                    logging.InstallLog.writeToFile("Created dnf.conf with MariaDB-server exclude")
+                            except Exception as e:
+                                self.stdOut(f"Warning: Could not add exclude to dnf.conf: {e}", 1)
+                                logging.InstallLog.writeToFile(f"Warning: Could not add exclude to dnf.conf: {e}")
                         
                         return True
                 except (ValueError, TypeError):
@@ -1764,7 +1770,12 @@ module cyberpanel_ols {
                             return True
                         else:
                             self.stdOut("⚠️  MariaDB 12.1 upgrade failed, using existing MariaDB installation", 1)
-                            self.startMariaDB()
+                            if not self.startMariaDB():
+                                self.stdOut("Existing MariaDB failed to start. Attempting repair install...", 1)
+                                if self.distro != ubuntu and os.environ.get("CYBERPANEL_EXCLUDE_MARIADB_SERVER", "0") != "1":
+                                    repair_cmd = "dnf install -y MariaDB-server MariaDB-client MariaDB-backup MariaDB-devel --allowerasing"
+                                    self.call(repair_cmd, self.distro, repair_cmd, repair_cmd, 1, 0, os.EX_OSERR, True)
+                                    self.startMariaDB()
                             return True
                     except Exception as upgrade_error:
                         error_msg = str(upgrade_error)
@@ -1779,13 +1790,23 @@ module cyberpanel_ols {
                             self.stdOut(f"Using existing MariaDB {installed_version} installation", 1)
                         
                         # Fall back to existing installation
-                        self.startMariaDB()
+                        if not self.startMariaDB():
+                            self.stdOut("Existing MariaDB failed to start. Attempting repair install...", 1)
+                            if self.distro != ubuntu and os.environ.get("CYBERPANEL_EXCLUDE_MARIADB_SERVER", "0") != "1":
+                                repair_cmd = "dnf install -y MariaDB-server MariaDB-client MariaDB-backup MariaDB-devel --allowerasing"
+                                self.call(repair_cmd, self.distro, repair_cmd, repair_cmd, 1, 0, os.EX_OSERR, True)
+                                self.startMariaDB()
                         return True
                 
                 # MariaDB 12.x or higher already installed, or version unknown but working
                 # Just ensure it's running
                 self.stdOut("Using existing MariaDB installation", 1)
-                self.startMariaDB()
+                if not self.startMariaDB():
+                    self.stdOut("Existing MariaDB failed to start. Attempting repair install...", 1)
+                    if self.distro != ubuntu and os.environ.get("CYBERPANEL_EXCLUDE_MARIADB_SERVER", "0") != "1":
+                        repair_cmd = "dnf install -y MariaDB-server MariaDB-client MariaDB-backup MariaDB-devel --allowerasing"
+                        self.call(repair_cmd, self.distro, repair_cmd, repair_cmd, 1, 0, os.EX_OSERR, True)
+                        self.startMariaDB()
                 return True
             
             self.stdOut("Installing MySQL/MariaDB...", 1)

--- a/install/install.py
+++ b/install/install.py
@@ -17,6 +17,8 @@ import stat
 import secrets
 import install_utils
 
+TMP_BASE = os.environ.get("TMPDIR", "/tmp")
+
 VERSION = '2.4'
 BUILD = 4
 
@@ -603,15 +605,15 @@ class preFlightsChecks:
                                         
                                         if alt_package in rpm_urls:
                                             # Download and install RPM directly
-                                            download_command = f"curl -L {rpm_urls[alt_package]} -o /tmp/{alt_package}.rpm"
+                                            download_command = f"curl -L {rpm_urls[alt_package]} -o {TMP_BASE}/{alt_package}.rpm"
                                             self.call(download_command, self.distro, f"Download {alt_package}", f"Download {alt_package}", 1, 0, os.EX_OSERR)
                                             
-                                            install_command = f"rpm -ivh /tmp/{alt_package}.rpm --force"
+                                            install_command = f"rpm -ivh {TMP_BASE}/{alt_package}.rpm --force"
                                             result = self.call(install_command, self.distro, f"Install {alt_package}", f"Install {alt_package}", 1, 0, os.EX_OSERR)
                                             if result == 1:
                                                 self.stdOut(f"Successfully installed {alt_package} via direct RPM download", 1)
                                                 # Clean up downloaded file
-                                                self.call(f"rm -f /tmp/{alt_package}.rpm", self.distro, f"Cleanup {alt_package}", f"Cleanup {alt_package}", 1, 0, os.EX_OSERR)
+                                                self.call(f"rm -f {TMP_BASE}/{alt_package}.rpm", self.distro, f"Cleanup {alt_package}", f"Cleanup {alt_package}", 1, 0, os.EX_OSERR)
                                                 break
                                     except:
                                         self.stdOut(f"Direct RPM download failed for {alt_package}", 1)
@@ -670,15 +672,15 @@ class preFlightsChecks:
                 if package and package in rpm_sources:
                     try:
                         self.stdOut(f"Trying direct RPM download for {package}...", 1)
-                        download_command = f"curl -L {rpm_sources[package]} -o /tmp/{package}.rpm"
+                        download_command = f"curl -L {rpm_sources[package]} -o {TMP_BASE}/{package}.rpm"
                         self.call(download_command, self.distro, f"Download {package}", f"Download {package}", 1, 0, os.EX_OSERR)
                         
-                        install_command = f"rpm -ivh /tmp/{package}.rpm --force"
+                        install_command = f"rpm -ivh {TMP_BASE}/{package}.rpm --force"
                         result = self.call(install_command, self.distro, f"Install {package}", f"Install {package}", 1, 0, os.EX_OSERR)
                         if result == 1:
                             self.stdOut(f"Successfully installed {package} via direct RPM download", 1)
                             # Clean up downloaded file
-                            self.call(f"rm -f /tmp/{package}.rpm", self.distro, f"Cleanup {package}", f"Cleanup {package}", 1, 0, os.EX_OSERR)
+                            self.call(f"rm -f {TMP_BASE}/{package}.rpm", self.distro, f"Cleanup {package}", f"Cleanup {package}", 1, 0, os.EX_OSERR)
                             installed = True
                     except:
                         self.stdOut(f"Direct RPM download failed for {package}", 1)
@@ -1222,8 +1224,8 @@ class preFlightsChecks:
                 self.stdOut(f"WARNING: Could not create backup: {e}", 1)
 
             # Download binaries to temp location
-            tmp_binary = "/tmp/openlitespeed-custom"
-            tmp_module = "/tmp/cyberpanel_ols.so"
+            tmp_binary = f"{TMP_BASE}/openlitespeed-custom"
+            tmp_module = f"{TMP_BASE}/cyberpanel_ols.so"
 
             self.stdOut("Downloading custom binaries...", 1)
 
@@ -3105,16 +3107,16 @@ module cyberpanel_ols {
                 download_url = "https://github.com/usmannasir/cyberpanel/archive/refs/heads/stable.zip"
                 extract_dir = "cyberpanel-stable"
             
-            command = f"wget -O /tmp/cyberpanel.zip {download_url}"
+            command = f"wget -O {TMP_BASE}/cyberpanel.zip {download_url}"
             preFlightsChecks.call(command, self.distro, command, command, 1, 1, os.EX_OSERR)
             
-            command = "unzip /tmp/cyberpanel.zip -d /usr/local/"
+            command = f"unzip {TMP_BASE}/cyberpanel.zip -d /usr/local/"
             preFlightsChecks.call(command, self.distro, command, command, 1, 1, os.EX_OSERR)
             
             command = f"mv /usr/local/{extract_dir} /usr/local/CyberCP"
             preFlightsChecks.call(command, self.distro, command, command, 1, 1, os.EX_OSERR)
             
-            command = "rm -f /tmp/cyberpanel.zip"
+            command = f"rm -f {TMP_BASE}/cyberpanel.zip"
             preFlightsChecks.call(command, self.distro, command, command, 1, 1, os.EX_OSERR)
             
             if not os.path.exists('/usr/local/CyberCP'):
@@ -3266,9 +3268,13 @@ password="%s"
 
         # Find the correct Python virtual environment path
         python_paths = [
-            "/usr/local/CyberPanel/bin/python",
             "/usr/local/CyberCP/bin/python",
-            "/usr/local/CyberPanel-venv/bin/python"
+            "/usr/local/CyberCP/bin/python3",
+            "/usr/local/CyberPanel/bin/python",
+            "/usr/local/CyberPanel/bin/python3",
+            "/usr/local/CyberPanel-venv/bin/python",
+            "/usr/local/CyberPanel-venv/bin/python3",
+            "/usr/bin/python3"
         ]
         
         python_path = None
@@ -3844,9 +3850,9 @@ $cfg['Servers'][$i]['LogoutURL'] = 'phpmyadminsignin.php?logout';
             elif self.distro == openeuler:
                 # AlmaLinux 9/10, RockyLinux 9, RHEL 9, CloudLinux 9, and other modern RHEL-based systems
                 dovecot_commands = [
-                    'dnf install dovecot dovecot-mysql -y --skip-broken --nobest',
-                    'dnf install dovecot23 dovecot23-mysql -y --skip-broken --nobest',
-                    'dnf install dovecot -y --skip-broken --nobest'
+                    'dnf install dovecot dovecot-mysql -y --skip-broken --nobest --allowerasing',
+                    'dnf install dovecot23 dovecot23-mysql -y --skip-broken --nobest --allowerasing',
+                    'dnf install dovecot -y --skip-broken --nobest --allowerasing'
                 ]
                 
                 dovecot_installed = False
@@ -4897,8 +4903,10 @@ user_query = SELECT email as user, password, 'vmail' as uid, 'vmail' as gid, '/h
 
             # Determine the correct Python path
             python_paths = [
-                "/usr/local/CyberPanel/bin/python",
                 "/usr/local/CyberCP/bin/python",
+                "/usr/local/CyberCP/bin/python3",
+                "/usr/local/CyberPanel/bin/python",
+                "/usr/local/CyberPanel/bin/python3",
                 "/usr/bin/python3",
                 "/usr/local/bin/python3"
             ]
@@ -4915,10 +4923,12 @@ user_query = SELECT email as user, password, 'vmail' as uid, 'vmail' as gid, '/h
                 preFlightsChecks.stdOut("Attempting to create virtual environment symlink...", 1)
                 
                 # Try to create symlink for compatibility
-                if os.path.exists('/usr/local/CyberCP/bin/python') and not os.path.exists('/usr/local/CyberPanel'):
+                if (os.path.exists('/usr/local/CyberCP/bin/python') or os.path.exists('/usr/local/CyberCP/bin/python3')) and not os.path.exists('/usr/local/CyberPanel'):
                     try:
                         os.symlink('/usr/local/CyberCP', '/usr/local/CyberPanel')
                         python_path = "/usr/local/CyberPanel/bin/python"
+                        if not os.path.exists(python_path) and os.path.exists("/usr/local/CyberPanel/bin/python3"):
+                            python_path = "/usr/local/CyberPanel/bin/python3"
                         preFlightsChecks.stdOut(f"Created symlink, using Python at: {python_path}", 1)
                     except Exception as e:
                         preFlightsChecks.stdOut(f"Failed to create symlink: {str(e)}", 0)
@@ -4970,8 +4980,11 @@ user_query = SELECT email as user, password, 'vmail' as uid, 'vmail' as gid, '/h
             # Check multiple possible virtual environment locations
             venv_paths = [
                 '/usr/local/CyberCP/bin/python',
+                '/usr/local/CyberCP/bin/python3',
                 '/usr/local/CyberPanel/bin/python',
-                '/usr/local/CyberPanel-venv/bin/python'
+                '/usr/local/CyberPanel/bin/python3',
+                '/usr/local/CyberPanel-venv/bin/python',
+                '/usr/local/CyberPanel-venv/bin/python3'
             ]
             
             found_venv = None
@@ -4986,14 +4999,13 @@ user_query = SELECT email as user, password, 'vmail' as uid, 'vmail' as gid, '/h
                 return False
             
             # Create symlinks for compatibility if needed
-            if found_venv == '/usr/local/CyberCP/bin/python':
-                if not os.path.exists('/usr/local/CyberPanel/bin/python'):
-                    if not os.path.exists('/usr/local/CyberPanel'):
-                        preFlightsChecks.stdOut("Creating CyberPanel symlink for compatibility", 1)
-                        os.symlink('/usr/local/CyberCP', '/usr/local/CyberPanel')
-                    else:
-                        preFlightsChecks.stdOut("CyberPanel directory exists but Python not found", 0)
-                        return False
+            if found_venv in ['/usr/local/CyberCP/bin/python', '/usr/local/CyberCP/bin/python3']:
+                if not os.path.exists('/usr/local/CyberPanel'):
+                    preFlightsChecks.stdOut("Creating CyberPanel symlink for compatibility", 1)
+                    os.symlink('/usr/local/CyberCP', '/usr/local/CyberPanel')
+                elif not (os.path.exists('/usr/local/CyberPanel/bin/python') or os.path.exists('/usr/local/CyberPanel/bin/python3')):
+                    preFlightsChecks.stdOut("CyberPanel directory exists but Python not found", 0)
+                    return False
             
             # Test if Python is executable
             try:
@@ -5018,8 +5030,10 @@ user_query = SELECT email as user, password, 'vmail' as uid, 'vmail' as gid, '/h
             
             # Determine the correct Python path
             python_paths = [
-                "/usr/local/CyberPanel/bin/python",
                 "/usr/local/CyberCP/bin/python",
+                "/usr/local/CyberCP/bin/python3",
+                "/usr/local/CyberPanel/bin/python",
+                "/usr/local/CyberPanel/bin/python3",
                 "/usr/bin/python3",
                 "/usr/local/bin/python3"
             ]
@@ -6036,9 +6050,9 @@ vmail
                         KEY type (type)
                     );
                     """
-                    with open('/tmp/powerdns_schema.sql', 'w') as f:
+                    with open(f'{TMP_BASE}/powerdns_schema.sql', 'w') as f:
                         f.write(basic_schema)
-                    preFlightsChecks.call("mysql powerdns < /tmp/powerdns_schema.sql", self.distro, "Create PowerDNS tables", "mysql powerdns < /tmp/powerdns_schema.sql", 1, 0, os.EX_OSERR)
+                    preFlightsChecks.call(f"mysql powerdns < {TMP_BASE}/powerdns_schema.sql", self.distro, "Create PowerDNS tables", f"mysql powerdns < {TMP_BASE}/powerdns_schema.sql", 1, 0, os.EX_OSERR)
             
         except Exception as e:
             preFlightsChecks.stdOut(f"Warning: Could not set up PowerDNS database access: {str(e)}", 0)
@@ -6108,8 +6122,22 @@ vmail
                 preFlightsChecks.stdOut(f"PowerDNS config copied to {dnsPath}")
                 config_file = dnsPath
             else:
-                preFlightsChecks.stdOut("[ERROR] PowerDNS template not found", 1)
-                return
+                preFlightsChecks.stdOut("[WARNING] PowerDNS template not found, creating basic config", 1)
+                mysqlPassword = getattr(self, 'mysql_Root_password', 'cyberpanel')
+                with open(dnsPath, 'w') as f:
+                    f.write("# PowerDNS MySQL Backend Configuration\n")
+                    f.write("launch=gmysql\n")
+                    f.write("gmysql-host=localhost\n")
+                    f.write("gmysql-port=3306\n")
+                    f.write("gmysql-user=cyberpanel\n")
+                    f.write(f"gmysql-password={mysqlPassword}\n")
+                    f.write("gmysql-dbname=cyberpanel\n")
+                    f.write("\n# Basic PowerDNS settings\n")
+                    f.write("daemon=no\n")
+                    f.write("guardian=no\n")
+                    f.write("setgid=pdns\n")
+                    f.write("setuid=pdns\n")
+                config_file = dnsPath
 
         # Now configure the existing or newly copied file
         if os.path.exists(config_file):


### PR DESCRIPTION
- Download installer into a HOME-backed temp file (avoids /tmp noexec)
- Use curl --location/--fail and clean up via trap
- Elevate via sudo/doas/run0/pkexec when not root
No functional changes outside installer bootstrap.